### PR TITLE
Fix front-end instructions and serve files via Flask

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,5 +12,5 @@ Aplicação simples em Flask que fornece a probabilidade de uma partida ter mais
    ```bash
    python app.py
    ```
-3. Abra o arquivo `web/index.html` em um navegador para testar a aplicação.
+3. Acesse `http://localhost:5000` em um navegador para testar a aplicação.
 

--- a/app.py
+++ b/app.py
@@ -4,7 +4,7 @@ import pandas as pd
 import joblib
 
 # Inicializar app Flask
-app = Flask(__name__)
+app = Flask(__name__, static_folder='web', static_url_path='')
 CORS(app, resources={r"/*": {"origins": "*"}})  # Libera CORS para tudo
 
 # Carregar modelo e scaler
@@ -21,6 +21,11 @@ times_disponiveis = [
     "Bahia",
     "Atletico Goianiense",
 ]
+
+
+@app.route('/')
+def index():
+    return app.send_static_file('index.html')
 
 @app.route('/predict', methods=['POST'])
 def prever():


### PR DESCRIPTION
## Summary
- serve static files directly from the Flask app
- add a route for `/` to return `index.html`
- update usage instructions in README

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6840515198908327834c4498a66389e1