### PR TITLE
Fix Vercel build missing csv

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,11 @@
 {
   "version": 2,
   "builds": [
-    { "src": "api/*.py", "use": "@vercel/python" },
+    {
+      "src": "api/*.py",
+      "use": "@vercel/python",
+      "config": { "includeFiles": ["api/dados_futebol.csv"] }
+    },
     { "src": "public/**/*", "use": "@vercel/static" }
   ],
   "routes": [


### PR DESCRIPTION
## Summary
- include the CSV data file in Vercel Python builds so API routes work in production

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840b3deea4c8327b9fcb3e9f0a376aa