### PR TITLE
Improve JSON error handling for team fetch

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -70,6 +70,10 @@ document.addEventListener("DOMContentLoaded", async () => {
 
   try {
     const res = await fetch("/teams");
+    if (!res.ok) {
+      const txt = await res.text();
+      throw new Error(txt || `Status ${res.status}`);
+    }
     const teams = await res.json();
     teams.forEach((t) => {
       const optHome = document.createElement("option");


### PR DESCRIPTION
## Summary
- handle non-OK HTTP responses when loading teams on the client

## Testing
- `python -m py_compile api/*.py`

------
https://chatgpt.com/codex/tasks/task_e_684192fa0798832785d5a64d7b9a82c3